### PR TITLE
Add FastAPI root endpoint test

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": "Welcome to Delivery Management System API",
+        "docs_url": "/docs",
+        "redoc_url": "/redoc",
+    }


### PR DESCRIPTION
## Summary
- add simple test using FastAPI TestClient to verify `/` response

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
